### PR TITLE
spec: build from git, not from local tarball.

### DIFF
--- a/.packit-copr-rpm.sh
+++ b/.packit-copr-rpm.sh
@@ -2,11 +2,9 @@
 
 # Custom spec handling for Packit's `fix-spec-file` action (.packit.yaml).
 #
-# Mirrors containers/netavark `.packit-copr-rpm.sh`:
-# https://github.com/containers/netavark/blob/main/.packit-copr-rpm.sh
-#
-# - Version / Release / Source0 / %autosetup from Cargo.toml + git HEAD
-# - Drops Source1 (vendor tarball); sets %%packit_no_vendor_tarball so %%prep skips `tar fx`
+# Copr-only: sync Version/Release/commit from HEAD.
+# Prefer forge HTTPS Source0 when the commit is on the remote; otherwise fall back
+# to a local git-archive-all tarball. Drops Source1 (vendor tarball).
 
 set -uexo pipefail
 
@@ -14,16 +12,27 @@ PACKAGE=conmon-v3
 SPEC_FILE=rpm/${PACKAGE}.spec
 
 VERSION=$(grep '^version' Cargo.toml | head -1 | cut -d'"' -f2)
+COMMIT=$(git rev-parse HEAD)
+FORGEURL=$(awk '/^%global forgeurl / { print $3 }' "${SPEC_FILE}")
+ARCHIVE_URL="${FORGEURL}/archive/${COMMIT}.tar.gz"
 
-# Source tarball from current HEAD (matches %autosetup -n below)
-git-archive-all -C "$(git rev-parse --show-toplevel)" \
-	--prefix="${PACKAGE}-${VERSION}/" \
-	"rpm/${PACKAGE}-${VERSION}.tar.gz"
-
-# Spec edits for Copr SRPM
 sed -i "s/^%global upstream_version.*/%global upstream_version ${VERSION}/" "${SPEC_FILE}"
+sed -i "s/^%global commit.*/%global commit ${COMMIT}/" "${SPEC_FILE}"
 sed -i "s/^Release:.*/Release: ${PACKIT_RPMSPEC_RELEASE}%{?dist}/" "${SPEC_FILE}"
-sed -i "s/^Source0:.*\\.tar\\.gz/Source0: ${PACKAGE}-${VERSION}.tar.gz/" "${SPEC_FILE}"
+
+if ! grep -q '^%global packit_no_vendor_tarball' "${SPEC_FILE}"; then
+	sed -i '/^Name:/a %global packit_no_vendor_tarball 1' "${SPEC_FILE}"
+fi
 sed -i "/^Source1/d" "${SPEC_FILE}"
-sed -i '/^Name:/a %global packit_no_vendor_tarball 1' "${SPEC_FILE}"
-sed -i "s/^%autosetup.*/%autosetup -Sgit -n ${PACKAGE}-${VERSION} -p1/" "${SPEC_FILE}"
+
+if curl -fsSIL --retry 2 "${ARCHIVE_URL}" >/dev/null; then
+	echo "Using forge Source0: ${ARCHIVE_URL}"
+else
+	echo "Commit ${COMMIT} not on forge; falling back to git-archive-all"
+	TARBALL="rpm/${PACKAGE}-${VERSION}.tar.gz"
+	git-archive-all -C "$(git rev-parse --show-toplevel)" \
+		--prefix="${PACKAGE}-${VERSION}/" \
+		"${TARBALL}"
+	sed -i "s|^Source0:.*|Source0: ${PACKAGE}-${VERSION}.tar.gz|" "${SPEC_FILE}"
+	sed -i "s|^%autosetup.*|%autosetup -Sgit -n ${PACKAGE}-${VERSION} -p1|" "${SPEC_FILE}"
+fi

--- a/rpm/conmon-v3.spec
+++ b/rpm/conmon-v3.spec
@@ -8,6 +8,9 @@
 %global repo conmon-v3
 # Cargo.toml version (hyphen); RPM Version uses tilde for ordering.
 %global upstream_version 3.0.0-dev
+# Forge snapshot; bump for manual SRPMs (Packit/Copr sets this from HEAD).
+%global commit 13fa97af947777881ecbf0cbf7238bee11292360
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 # Build environment toggles.
 %global conmon_is_rhel 0%{?rhel:1}
@@ -32,7 +35,7 @@ License:        %{shrink:
 }
 
 URL:            %{forgeurl}
-Source0:        %{forgeurl}/archive/v%{upstream_version}/%{repo}-%{upstream_version}.tar.gz
+Source0:        %{forgeurl}/archive/%{commit}.tar.gz#/%{repo}-%{shortcommit}.tar.gz
 Source1:        %{forgeurl}/releases/download/v%{upstream_version}/%{repo}-v%{upstream_version}-vendor.tar.gz
 
 %if %{defined golang_arches_future}
@@ -61,7 +64,7 @@ Requires:       libseccomp
 %{summary}.
 
 %prep
-%autosetup -Sgit -n %{repo}-%{upstream_version} -p1
+%autosetup -Sgit -n %{repo}-%{commit} -p1
 %if %{defined copr_username} || %{defined packit_no_vendor_tarball}
 %cargo_prep -N
 # %%cargo_prep always sets [net] offline = true (Koji); Copr/Packit need crates.io with enable_net.


### PR DESCRIPTION
Use the current git commit as Source0 for Copr builds, falling back to a locally generated archive when the commit is not available on the remote forge.