### PR TITLE
exit: atomically write container exit status files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
+name = "atomic-write-file"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84790c55b5704b0d35130bf16a4ce22a8e70eb0ea773522557524d9a4852663d"
+dependencies = [
+ "nix",
+ "rand",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,6 +128,7 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 name = "conmon"
 version = "3.0.0-dev"
 dependencies = [
+ "atomic-write-file",
  "chrono",
  "clap",
  "log",
@@ -369,6 +380,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "predicates"
 version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,6 +437,35 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "rustix"
@@ -675,3 +724,23 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ serde_json = "1"
 log = { version = "0.4", features = ["std"] }
 chrono = "0.4"
 systemd = { version = "0.10.1", default-features = false, features = ["journal"] }
+atomic-write-file = "0.3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -1,15 +1,17 @@
 use crate::error::{ConmonError, ConmonResult};
 
+use atomic_write_file::AtomicWriteFile;
 use log::{error, info, warn};
 use nix::errno::Errno;
 use nix::sys::wait::waitpid;
 use nix::unistd::Pid;
 
+use std::io::{self, Write};
 use std::os::fd::RawFd;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::thread;
 use std::time::Duration;
-use std::{fs, thread};
 
 use nix::libc::{PR_SET_CHILD_SUBREAPER, close, prctl};
 
@@ -102,6 +104,17 @@ pub fn run_exit_command(
     Ok(())
 }
 
+/// Atomically write `contents` to `path` via `atomic-write-file`.
+///
+/// Same intent as conmon-v2 `g_file_set_contents`: inotify waiters never see a
+/// truncated/empty exit file.
+fn write_file_atomic(path: &Path, contents: &str) -> io::Result<()> {
+    let mut file = AtomicWriteFile::options().open(path)?;
+    file.write_all(contents.as_bytes())?;
+    file.commit()?;
+    Ok(())
+}
+
 /// Writes exit files into persistent_path and exit_dir.
 pub fn write_exit_files(
     exit_status: i32,
@@ -114,7 +127,7 @@ pub fn write_exit_files(
     // Write the exit file to container persistent directory if it is specified
     if let Some(persist_path) = persist_path {
         let ctr_exit_file_path: PathBuf = persist_path.join("exit");
-        if let Err(e) = fs::write(&ctr_exit_file_path, &status_str) {
+        if let Err(e) = write_file_atomic(&ctr_exit_file_path, &status_str) {
             error!(
                 "Failed to write {} to container exit file {}: {}",
                 status_str,
@@ -129,7 +142,7 @@ pub fn write_exit_files(
     if let Some(exit_dir) = exit_dir {
         if let Some(cid) = cid {
             let exit_file_path: PathBuf = exit_dir.join(cid);
-            if let Err(e) = fs::write(&exit_file_path, &status_str) {
+            if let Err(e) = write_file_atomic(&exit_file_path, &status_str) {
                 error!(
                     "Failed to write {} to exit file {}: {}",
                     status_str,
@@ -227,5 +240,112 @@ pub fn close_all_except_stdio(snap: &OpenFilesSnapshot) {
             // Best-effort: ignore EBADF and any other errors (common when racing / already closed).
             let _ = unsafe { close(fd) };
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io;
+    use std::thread;
+    use tempfile::tempdir;
+
+    #[test]
+    fn write_exit_files_writes_contents() -> io::Result<()> {
+        let dir = tempdir()?;
+        let persist = dir.path().to_path_buf();
+
+        write_exit_files(42, Some(&persist), None, None);
+
+        let path = persist.join("exit");
+        assert_eq!(std::fs::read_to_string(&path)?, "42");
+        Ok(())
+    }
+
+    #[test]
+    fn write_exit_files_replaces_existing_file() -> io::Result<()> {
+        let dir = tempdir()?;
+        let persist = dir.path().to_path_buf();
+        std::fs::write(persist.join("exit"), "old")?;
+
+        write_exit_files(7, Some(&persist), None, None);
+
+        assert_eq!(std::fs::read_to_string(persist.join("exit"))?, "7");
+        Ok(())
+    }
+
+    #[test]
+    fn write_exit_files_leaves_no_temp_files() -> io::Result<()> {
+        let dir = tempdir()?;
+        let persist = dir.path().to_path_buf();
+
+        write_exit_files(0, Some(&persist), None, None);
+
+        let leftovers: Vec<_> = std::fs::read_dir(dir.path())?
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name())
+            .filter(|n| {
+                let name = n.to_string_lossy();
+                name != "exit" && name.starts_with('.')
+            })
+            .collect();
+        assert!(leftovers.is_empty(), "leftover temps: {leftovers:?}");
+        Ok(())
+    }
+
+    #[test]
+    fn write_exit_files_replaces_destination_symlink_not_target() -> io::Result<()> {
+        let dir = tempdir()?;
+        let persist = dir.path().to_path_buf();
+        let target = dir.path().join("secret");
+        std::fs::write(&target, "untouched")?;
+        std::os::unix::fs::symlink(&target, persist.join("exit"))?;
+
+        write_exit_files(1, Some(&persist), None, None);
+
+        let path = persist.join("exit");
+        assert_eq!(std::fs::read_to_string(&path)?, "1");
+        assert_eq!(std::fs::read_to_string(&target)?, "untouched");
+        assert!(!std::fs::symlink_metadata(&path)?.file_type().is_symlink());
+        Ok(())
+    }
+
+    #[test]
+    fn write_exit_files_to_exit_dir_uses_cid_name() -> io::Result<()> {
+        let dir = tempdir()?;
+        let exit_dir = dir.path().to_path_buf();
+        let cid = String::from("abc123");
+
+        write_exit_files(9, None, Some(&exit_dir), Some(&cid));
+
+        assert_eq!(std::fs::read_to_string(exit_dir.join(&cid))?, "9");
+        Ok(())
+    }
+
+    #[test]
+    fn write_file_atomic_concurrent_writers_do_not_clobber_temp() -> io::Result<()> {
+        let dir = tempdir()?;
+        let path = dir.path().join("exit");
+
+        let mut handles = Vec::new();
+        for i in 0..8 {
+            let path = path.clone();
+            handles.push(thread::spawn(move || {
+                write_file_atomic(&path, &i.to_string())
+            }));
+        }
+        for h in handles {
+            h.join().expect("thread panicked")?;
+        }
+
+        let contents = std::fs::read_to_string(&path)?;
+        assert!(
+            matches!(
+                contents.as_str(),
+                "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7"
+            ),
+            "unexpected contents {contents:?}"
+        );
+        Ok(())
     }
 }


### PR DESCRIPTION
Write exit files via a temp file and rename so inotify waiters never see a truncated or empty file before podman reads the final status.