### PR TITLE
runtime: reliably report exec and container exit status

### DIFF
--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -35,6 +35,7 @@ impl Exec {
         runtime_session.wait_for_success(self.cfg.common.api_version, true)?;
 
         runtime_session.write_container_pid_file(&self.cfg.common)?;
+        runtime_session.reap_pending_children()?;
 
         // Run the eventloop to forward log messages to log plugin.
         runtime_session.run_event_loop(

--- a/src/runtime/process.rs
+++ b/src/runtime/process.rs
@@ -3,16 +3,18 @@ use crate::exit::set_subreaper;
 use crate::runtime::stdio::read_pipe;
 
 use log::{info, warn};
+use nix::errno::Errno;
 use nix::fcntl::{OFlag, open};
 use nix::sys::signal::{SigSet, SigmaskHow, Signal, kill, pthread_sigmask};
 use nix::sys::stat::Mode;
-use nix::sys::wait::{WaitStatus, waitpid};
+use nix::sys::wait::{WaitPidFlag, WaitStatus, waitpid};
 use nix::unistd::{
     ForkResult, Pid, dup2_stderr, dup2_stdin, dup2_stdout, fork, getpid, getppid, setsid,
 };
 
 use std::env;
-use std::io::{Error, Result as IoResult};
+use std::fs;
+use std::io::{Error, ErrorKind, Result as IoResult};
 use std::os::fd::{AsFd, OwnedFd};
 use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
@@ -22,6 +24,80 @@ use std::process::{Command, Stdio, exit};
 /// Convert a nix::Error into std::io::Error (for use inside pre_exec closure).
 fn io_err(e: nix::Error) -> Error {
     Error::from_raw_os_error(e as i32)
+}
+
+/// Definitive liveness of a process as observed via `/proc`.
+///
+/// Callers must not treat [`ProcessStatus::Unknown`] as exit: that covers
+/// permission failures, transient I/O errors, and unparseable `/proc` contents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessStatus {
+    /// Process exists and is not zombie/dead.
+    Running,
+    /// Process is gone (`ENOENT`) or is zombie/dead (`Z`/`X`/`x`).
+    Exited,
+    /// Status could not be determined; keep polling / retry.
+    Unknown,
+}
+
+/// Parse the one-letter process state from the contents of `/proc/<pid>/stat`.
+fn state_from_proc_stat(contents: &str) -> Option<char> {
+    let rparen = contents.rfind(')')?;
+    contents.get(rparen + 2..)?.chars().next()
+}
+
+fn process_status_from_state(state: char) -> ProcessStatus {
+    match state {
+        // Zombie or dead: treat as exited. `kill(pid, 0)` still succeeds for zombies.
+        'Z' | 'X' | 'x' => ProcessStatus::Exited,
+        _ => ProcessStatus::Running,
+    }
+}
+
+/// Map a `/proc/<pid>/stat` read result to [`ProcessStatus`].
+///
+/// Only `NotFound` and a definitive zombie/dead state mean [`ProcessStatus::Exited`].
+/// Any other I/O failure or parse failure is [`ProcessStatus::Unknown`].
+fn process_status_from_stat_result(result: Result<String, Error>) -> ProcessStatus {
+    match result {
+        Ok(contents) => match state_from_proc_stat(&contents) {
+            Some(state) => process_status_from_state(state),
+            None => ProcessStatus::Unknown,
+        },
+        Err(e) if e.kind() == ErrorKind::NotFound => ProcessStatus::Exited,
+        Err(_) => ProcessStatus::Unknown,
+    }
+}
+
+/// Observe whether `pid` is still running via `/proc/<pid>/stat`.
+///
+/// `kill(pid, 0)` also succeeds for zombie processes, so callers must not use
+/// that syscall alone to decide whether a container is still running.
+pub fn process_status(pid: i32) -> ProcessStatus {
+    if pid <= 0 {
+        return ProcessStatus::Unknown;
+    }
+    process_status_from_stat_result(fs::read_to_string(format!("/proc/{pid}/stat")))
+}
+
+/// Non-blocking wait for a specific PID.
+///
+/// As subreaper, conmon may reap orphaned container processes this way even when
+/// they are not returned by `waitpid(-1, WNOHANG)`.
+pub fn try_wait_process(pid: i32) -> Result<Option<WaitStatus>, Errno> {
+    let pid = Pid::from_raw(pid);
+    loop {
+        match waitpid(pid, Some(WaitPidFlag::WNOHANG)) {
+            Ok(WaitStatus::StillAlive) => return Ok(None),
+            Ok(status @ (WaitStatus::Exited(_, _) | WaitStatus::Signaled(_, _, _))) => {
+                return Ok(Some(status));
+            }
+            Ok(_) => return Ok(None),
+            Err(Errno::ECHILD) => return Ok(None),
+            Err(Errno::EINTR) => continue,
+            Err(e) => return Err(e),
+        }
+    }
 }
 
 /// Block signals in the parent before we spawn.
@@ -235,5 +311,106 @@ impl RuntimeProcess {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn state_from_proc_stat_parses_zombie() {
+        assert_eq!(state_from_proc_stat("42 (sh) Z 1 42 42"), Some('Z'));
+    }
+
+    #[test]
+    fn state_from_proc_stat_parses_running() {
+        assert_eq!(state_from_proc_stat("99 (sleep) S 1 99 99"), Some('S'));
+    }
+
+    #[test]
+    fn state_from_proc_stat_rejects_malformed() {
+        assert_eq!(state_from_proc_stat("no-paren Z"), None);
+        assert_eq!(state_from_proc_stat("1 (x)"), None);
+    }
+
+    #[test]
+    fn process_status_from_stat_result_running() {
+        assert_eq!(
+            process_status_from_stat_result(Ok("99 (sleep) S 1 99 99".into())),
+            ProcessStatus::Running
+        );
+    }
+
+    #[test]
+    fn process_status_from_stat_result_zombie_is_exited() {
+        assert_eq!(
+            process_status_from_stat_result(Ok("42 (sh) Z 1 42 42".into())),
+            ProcessStatus::Exited
+        );
+    }
+
+    #[test]
+    fn process_status_from_stat_result_dead_is_exited() {
+        assert_eq!(
+            process_status_from_stat_result(Ok("7 (x) X 1 7 7".into())),
+            ProcessStatus::Exited
+        );
+    }
+
+    #[test]
+    fn process_status_from_stat_result_enoent_is_exited() {
+        assert_eq!(
+            process_status_from_stat_result(Err(Error::new(
+                ErrorKind::NotFound,
+                "No such file or directory"
+            ))),
+            ProcessStatus::Exited
+        );
+    }
+
+    #[test]
+    fn process_status_from_stat_result_permission_is_unknown() {
+        assert_eq!(
+            process_status_from_stat_result(Err(Error::new(
+                ErrorKind::PermissionDenied,
+                "Permission denied"
+            ))),
+            ProcessStatus::Unknown
+        );
+    }
+
+    #[test]
+    fn process_status_from_stat_result_other_io_is_unknown() {
+        assert_eq!(
+            process_status_from_stat_result(Err(Error::other("I/O error"))),
+            ProcessStatus::Unknown
+        );
+    }
+
+    #[test]
+    fn process_status_from_stat_result_malformed_is_unknown() {
+        assert_eq!(
+            process_status_from_stat_result(Ok("garbage".into())),
+            ProcessStatus::Unknown
+        );
+    }
+
+    #[test]
+    fn process_status_for_current_process_is_running() {
+        let pid = std::process::id() as i32;
+        assert_eq!(process_status(pid), ProcessStatus::Running);
+    }
+
+    #[test]
+    fn process_status_for_nonexistent_pid_is_exited() {
+        // PIDs this high are unused on Linux; /proc/<pid>/stat returns ENOENT.
+        assert_eq!(process_status(i32::MAX), ProcessStatus::Exited);
+    }
+
+    #[test]
+    fn process_status_for_invalid_pid_is_unknown() {
+        assert_eq!(process_status(0), ProcessStatus::Unknown);
+        assert_eq!(process_status(-1), ProcessStatus::Unknown);
     }
 }

--- a/src/runtime/session.rs
+++ b/src/runtime/session.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::os::fd::{AsFd, AsRawFd};
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{fs, os::fd::OwnedFd, path::PathBuf, process::Stdio};
@@ -8,7 +9,6 @@ use nix::sys::signalfd::{SfdFlags, SignalFd};
 use nix::unistd::{Pid, getpgid};
 use nix::{
     errno::Errno,
-    libc,
     sys::{
         socket::{SockFlag, SockType},
         stat::Mode,
@@ -26,11 +26,21 @@ use crate::{
     runtime::{
         args::{RuntimeArgsGenerator, generate_runtime_args},
         ctl::{setup_console_fifo, setup_terminal_control_fifo},
-        process::RuntimeProcess,
+        process::{ProcessStatus, RuntimeProcess, process_status, try_wait_process},
         stdio::{create_pipe, handle_stdio, read_pipe, receive_console_fd},
     },
     unix_socket::{RemoteSocket, SocketType, UnixSocket},
 };
+
+/// Result of a single non-blocking child-process poll during the event loop.
+enum PollChildrenResult {
+    /// Keep polling sockets and reaping children.
+    KeepRunning,
+    /// Stop the event loop (container or runtime finished).
+    StopEventLoop,
+    /// Reaped an unrelated child; call again to drain more zombies.
+    ReapedOther,
+}
 
 /// Represents Runtime session.
 /// Handles spawning of runtime process, reading its stdio, writing its
@@ -114,6 +124,10 @@ pub struct RuntimeSession {
 
     // Open file descriptor snapshot.
     open_files: OpenFilesSnapshot,
+
+    /// Exit statuses for children reaped before `container_pid` was registered.
+    /// Mirrors conmon-v2's `exit_status_cache` for fast-exiting exec processes.
+    exit_status_cache: HashMap<i32, WaitStatus>,
 }
 
 impl RuntimeSession {
@@ -145,7 +159,11 @@ impl RuntimeSession {
     ///
     /// * The exit code of container.
     pub fn container_exit_code(&self) -> i32 {
-        self.container_status
+        if self.timed_out {
+            -1
+        } else {
+            self.container_status
+        }
     }
 
     /// Reads and returns the container's PID.
@@ -423,21 +441,27 @@ impl RuntimeSession {
     ///
     /// * [`ConmonError`] on any error.
     pub fn write_container_pid_file(&mut self, common: &CommonCfg) -> ConmonResult<()> {
+        // Reap exec processes that exited while the runtime process was still running.
+        self.drain_exit_status_cache_from_children()?;
+
         // Read the container PID and store it.
         self.container_pid = self.read_container_pid(common)?;
+        // Preserve the PID for the sync pipe / OOM setup even if a cached exit
+        // status immediately clears `container_pid` (fast-exiting exec).
+        let reported_pid = self.container_pid;
+        self.apply_exit_status_cache_for_container_pid();
 
         // We know the container started, so note it.
         self.container_started = true;
 
         // Setup the out-of-mana (eh, *-memory) handler, so we can detect OOM event
         // and pass it to parent.
-        self.oom_socket =
-            setup_oom_handling(self.container_pid, &common.persist_dir, &common.bundle)?;
+        self.oom_socket = setup_oom_handling(reported_pid, &common.persist_dir, &common.bundle)?;
 
         // Pass the container_pid to sync_pipe if there is one.
         if let Some(fd) = self.sync_pipe_fd.take() {
             self.sync_pipe_fd =
-                write_or_close_sync_fd(fd, self.container_pid, None, common.api_version, false)?;
+                write_or_close_sync_fd(fd, reported_pid, None, common.api_version, false)?;
         }
 
         Ok(())
@@ -476,8 +500,13 @@ impl RuntimeSession {
             // Prepare the exit code according to the `write_exit_code`.
             let mut to_report = -1;
 
-            if self.container_started {
-                to_report = self.container_status
+            if self.timed_out {
+                to_report = -1;
+            } else if self.container_started {
+                if self.container_status < 0 {
+                    self.finalize_container_exit()?;
+                }
+                to_report = self.container_status;
             } else if write_exit_code && self.exit_code > 0 {
                 to_report = -self.exit_code;
             }
@@ -557,6 +586,213 @@ impl RuntimeSession {
         Ok(())
     }
 
+    /// Records a `waitpid` result for the tracked container PID and decides
+    /// whether the event loop should stop.
+    fn handle_container_wait_status(&mut self, status: WaitStatus) -> ConmonResult<bool> {
+        match status {
+            WaitStatus::Exited(_, code) => {
+                self.container_status = code;
+                self.container_pid = -1;
+                info!("Container exited: {}", self.container_status);
+                Ok(false)
+            }
+            WaitStatus::Signaled(_, signal, _) => {
+                self.container_status = 128 + signal as i32;
+                self.container_pid = -1;
+                info!("Container killed with signal: {}", self.container_status);
+                Ok(false)
+            }
+            _ => Ok(true),
+        }
+    }
+
+    /// Cache exit status for a child reaped before `container_pid` was registered.
+    fn cache_child_exit(&mut self, pid: i32, status: WaitStatus) {
+        info!("Caching exit status for child {pid}");
+        self.exit_status_cache.insert(pid, status);
+    }
+
+    /// Apply a previously cached exit status once `container_pid` is known.
+    fn apply_exit_status_cache_for_container_pid(&mut self) {
+        if self.container_pid <= 0 {
+            return;
+        }
+        if let Some(status) = self.exit_status_cache.remove(&self.container_pid) {
+            info!(
+                "Applying cached exit status for container pid {}",
+                self.container_pid
+            );
+            let _ = self.handle_container_wait_status(status);
+        }
+    }
+
+    /// Reap children that exited while the runtime process was still running.
+    fn drain_exit_status_cache_from_children(&mut self) -> ConmonResult<()> {
+        while let PollChildrenResult::ReapedOther = self.poll_children_once()? {}
+        Ok(())
+    }
+
+    /// When the process is gone but its exit status is unknown, assume success only
+    /// if we never recorded a status (matches conmon-v2's ECHILD fallback).
+    fn assume_container_exited_without_status(&mut self) {
+        if self.container_status < 0 {
+            info!("Container process has exited with unknown status; assuming 0");
+            self.container_status = 0;
+        }
+        self.container_pid = -1;
+    }
+
+    /// Non-blocking wait for any child, mirroring conmon-v2's `check_child_processes`.
+    fn poll_children_once(&mut self) -> ConmonResult<PollChildrenResult> {
+        let res = waitpid(Pid::from_raw(-1), Some(WaitPidFlag::WNOHANG));
+
+        match res {
+            Err(Errno::EINTR) => Ok(PollChildrenResult::KeepRunning),
+
+            Err(Errno::ECHILD) => {
+                if self.container_pid > 0 {
+                    let pid = self.container_pid;
+
+                    if let Some(status) = try_wait_process(pid)? {
+                        return if self.handle_container_wait_status(status)? {
+                            Ok(PollChildrenResult::KeepRunning)
+                        } else {
+                            Ok(PollChildrenResult::StopEventLoop)
+                        };
+                    }
+
+                    match process_status(pid) {
+                        ProcessStatus::Running => {
+                            info!("Container process {pid} is still alive but not a direct child");
+                            return Ok(PollChildrenResult::KeepRunning);
+                        }
+                        ProcessStatus::Unknown => {
+                            // Permission/I/O/parse failure — do not invent an exit code.
+                            info!("Container process {pid} status unknown via /proc; will retry");
+                            return Ok(PollChildrenResult::KeepRunning);
+                        }
+                        ProcessStatus::Exited => {
+                            info!("Container process {pid} has exited (detected via /proc)");
+                            self.assume_container_exited_without_status();
+                            return Ok(PollChildrenResult::StopEventLoop);
+                        }
+                    }
+                }
+
+                // Container already reaped (status known, pid cleared) or never started.
+                // Do not keep the event loop alive forever on ECHILD.
+                if self.container_status >= 0 || !self.container_started {
+                    Ok(PollChildrenResult::StopEventLoop)
+                } else {
+                    Ok(PollChildrenResult::KeepRunning)
+                }
+            }
+
+            Err(e) => Err(ConmonError::new(
+                format!("Failed to read child process status: {e}"),
+                1,
+            )),
+
+            Ok(WaitStatus::StillAlive) => Ok(PollChildrenResult::KeepRunning),
+
+            Ok(WaitStatus::Exited(p, code)) => {
+                if p == Pid::from_raw(self.container_pid) {
+                    if self.handle_container_wait_status(WaitStatus::Exited(p, code))? {
+                        Ok(PollChildrenResult::KeepRunning)
+                    } else {
+                        Ok(PollChildrenResult::StopEventLoop)
+                    }
+                } else if p == Pid::from_raw(self.process.pid()) {
+                    self.exit_code = code;
+                    info!("Runtime exited: {}", self.exit_code);
+                    Ok(PollChildrenResult::StopEventLoop)
+                } else {
+                    let pid = p.as_raw();
+                    info!("Unknown child {pid} exited");
+                    self.cache_child_exit(pid, WaitStatus::Exited(p, code));
+                    Ok(PollChildrenResult::ReapedOther)
+                }
+            }
+
+            Ok(WaitStatus::Signaled(p, s, coredump)) => {
+                if p == Pid::from_raw(self.container_pid) {
+                    if self.handle_container_wait_status(WaitStatus::Signaled(p, s, coredump))? {
+                        Ok(PollChildrenResult::KeepRunning)
+                    } else {
+                        Ok(PollChildrenResult::StopEventLoop)
+                    }
+                } else if p == Pid::from_raw(self.process.pid()) {
+                    self.exit_code = 128 + s as i32;
+                    info!("Runtime killed with signal: {}", self.exit_code);
+                    Ok(PollChildrenResult::StopEventLoop)
+                } else {
+                    let pid = p.as_raw();
+                    info!("Unknown child {pid} exited");
+                    self.cache_child_exit(pid, WaitStatus::Signaled(p, s, coredump));
+                    Ok(PollChildrenResult::ReapedOther)
+                }
+            }
+
+            Ok(
+                WaitStatus::Stopped(_, _)
+                | WaitStatus::Continued(_)
+                | WaitStatus::PtraceEvent(_, _, _)
+                | WaitStatus::PtraceSyscall(_),
+            ) => Ok(PollChildrenResult::KeepRunning),
+        }
+    }
+
+    /// Reap any children that already exited before the event loop runs.
+    ///
+    /// Exec processes can finish immediately after the PID is written to the sync pipe.
+    pub fn reap_pending_children(&mut self) -> ConmonResult<()> {
+        loop {
+            if self.container_status >= 0 {
+                return Ok(());
+            }
+            match self.poll_children_once()? {
+                PollChildrenResult::ReapedOther => continue,
+                PollChildrenResult::KeepRunning | PollChildrenResult::StopEventLoop => {
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    /// Ensure the container exit status is known before writing exit files.
+    pub fn finalize_container_exit(&mut self) -> ConmonResult<()> {
+        if self.container_status >= 0 {
+            return Ok(());
+        }
+
+        self.reap_pending_children()?;
+        if self.container_status >= 0 {
+            return Ok(());
+        }
+
+        if self.container_pid > 0 {
+            let pid = self.container_pid;
+            if let Some(status) = try_wait_process(pid)? {
+                let _ = self.handle_container_wait_status(status)?;
+                return Ok(());
+            }
+            match process_status(pid) {
+                ProcessStatus::Exited => {
+                    info!("Container process {pid} has exited (final probe)");
+                    self.assume_container_exited_without_status();
+                }
+                ProcessStatus::Running => {}
+                ProcessStatus::Unknown => {
+                    info!(
+                        "Container process {pid} status unknown via /proc at finalize; leaving unset"
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     /// Function executed periodically during the event-loop execuction.
     ///
     /// This function monitors the signal-fd, all the children processes and
@@ -574,6 +810,12 @@ impl RuntimeSession {
     ///
     /// * [`ConmonError`] on any error.
     fn idle_callback(&mut self, signal_received: bool) -> ConmonResult<bool> {
+        // Fast-exiting exec processes may already have a recorded status before
+        // the event loop starts (or right after the first reap). Stop immediately.
+        if self.container_status >= 0 {
+            return Ok(false);
+        }
+
         // We received a signal.
         if signal_received {
             if let Some(signals) = &self.signals {
@@ -593,7 +835,7 @@ impl RuntimeSession {
                     Err(_) => return Ok(true),
                 }
             }
-            return Ok(true);
+            return Ok(self.container_status < 0);
         }
 
         // Stop the event-loop if we reach a timeout.
@@ -621,98 +863,9 @@ impl RuntimeSession {
             return Ok(false);
         }
 
-        // Wait for any child to finish (non-blocking).
-        let res = waitpid(Pid::from_raw(-1), Some(WaitPidFlag::WNOHANG));
-
-        match res {
-            // Interrupted by signal - retry.
-            Err(Errno::EINTR) => Ok(true),
-
-            // no more child processes
-            Err(Errno::ECHILD) => {
-                // Before quitting, probe the container_pid.
-                // It might not be a direct child.
-                if self.container_pid > 0 {
-                    // Nix kill function does not support 0 signal, so we have to use libc one.
-                    let rc = unsafe { libc::kill(self.container_pid, 0) };
-                    if rc == 0 {
-                        info!(
-                            "Container process {} is still alive but not a direct child",
-                            self.container_pid
-                        );
-                        // Do not quit main loop yet...
-                        return Ok(true);
-                    } else if Errno::last() == Errno::ESRCH {
-                        // Process exited.
-                        info!(
-                            "Container process {} has exited (detected via kill probe)",
-                            self.container_pid
-                        );
-                        // We cannot get real exit status.
-                        self.container_status = 0;
-                        self.container_pid = -1;
-                        return Ok(false);
-                    } else {
-                        info!("No more child processes.");
-                        return Ok(false);
-                    }
-                }
-
-                // If container has not started yet, keep running.
-                Ok(!self.container_started)
-            }
-
-            // some other waitpid error
-            Err(e) => Err(ConmonError::new(
-                format!("Failed to read child process status: {e}"),
-                1,
-            )),
-
-            // No child has changed state.
-            Ok(WaitStatus::StillAlive) => Ok(true),
-
-            // Child exited, store the exit code.
-            Ok(WaitStatus::Exited(p, code)) => {
-                if p == Pid::from_raw(self.container_pid) {
-                    self.container_status = code;
-                    info!("Container exited: {}", self.container_status);
-                    return Ok(false);
-                } else if p == Pid::from_raw(self.process.pid()) {
-                    self.exit_code = code;
-                    info!("Runtime exited: {}", self.exit_code);
-                    return Ok(false);
-                } else {
-                    info!("Uknown child {} exited", p);
-                }
-                Ok(true)
-            }
-
-            // Child killed with a signal, store it as exit code.
-            Ok(WaitStatus::Signaled(p, s, _)) => {
-                let code: i32 = s as i32;
-                if p == Pid::from_raw(self.container_pid) {
-                    self.container_status = 128 + code;
-                    info!("Container killed with signal: {}", self.container_status);
-                    return Ok(false);
-                } else if p == Pid::from_raw(self.process.pid()) {
-                    self.exit_code = 128 + code;
-                    info!("Runtime killed with signal: {}", self.exit_code);
-                    return Ok(false);
-                } else {
-                    info!("Uknown child {} exited", p);
-                }
-                Ok(true)
-            }
-
-            Ok(
-                WaitStatus::Stopped(_, _)
-                | WaitStatus::Continued(_)
-                | WaitStatus::PtraceEvent(_, _, _)
-                | WaitStatus::PtraceSyscall(_),
-            ) => {
-                // Just continue with the event-loop.
-                Ok(true)
-            }
+        match self.poll_children_once()? {
+            PollChildrenResult::KeepRunning | PollChildrenResult::ReapedOther => Ok(true),
+            PollChildrenResult::StopEventLoop => Ok(false),
         }
     }
 
@@ -758,6 +911,7 @@ impl RuntimeSession {
                 signal_fd,
                 |signal_received| self.idle_callback(signal_received),
             )?;
+            self.finalize_container_exit()?;
             return Ok(());
         }
 
@@ -926,6 +1080,84 @@ mod tests {
                 .unwrap()
                 .contains("runc create failed")
         );
+        Ok(())
+    }
+
+    #[test]
+    fn finalize_container_exit_probes_exited_pid() -> ConmonResult<()> {
+        let open_files = OpenFilesSnapshot::default();
+        let mut sess = RuntimeSession::new(open_files);
+        sess.container_started = true;
+        sess.container_pid = nix::unistd::getpid().as_raw();
+        // Current process is alive; finalize should leave status unset.
+        sess.finalize_container_exit()?;
+        assert_eq!(sess.container_status, -1);
+
+        // A PID that no longer exists should be treated as exited.
+        sess.container_status = -1;
+        sess.container_pid = 999_999_999;
+        sess.finalize_container_exit()?;
+        assert_eq!(sess.container_status, 0);
+        assert_eq!(sess.container_pid, -1);
+        Ok(())
+    }
+
+    #[test]
+    fn finalize_container_exit_is_noop_when_status_known() -> ConmonResult<()> {
+        let open_files = OpenFilesSnapshot::default();
+        let mut sess = RuntimeSession::new(open_files);
+        sess.container_started = true;
+        sess.container_status = 1;
+        sess.container_pid = 999_999_999;
+        sess.finalize_container_exit()?;
+        assert_eq!(sess.container_status, 1);
+        assert_eq!(sess.container_pid, 999_999_999);
+        Ok(())
+    }
+
+    #[test]
+    fn cached_child_exit_is_applied_for_container_pid() {
+        let open_files = OpenFilesSnapshot::default();
+        let mut sess = RuntimeSession::new(open_files);
+        sess.cache_child_exit(4242, WaitStatus::Exited(Pid::from_raw(4242), 7));
+        sess.container_pid = 4242;
+        sess.apply_exit_status_cache_for_container_pid();
+        assert_eq!(sess.container_status, 7);
+        assert_eq!(sess.container_pid, -1);
+    }
+
+    #[test]
+    fn container_exit_code_is_minus_one_after_timeout() {
+        let open_files = OpenFilesSnapshot::default();
+        let mut sess = RuntimeSession::new(open_files);
+        sess.container_status = 137;
+        sess.timed_out = true;
+        assert_eq!(sess.container_exit_code(), -1);
+    }
+
+    #[test]
+    fn poll_children_stops_after_status_known_and_pid_cleared() -> ConmonResult<()> {
+        let open_files = OpenFilesSnapshot::default();
+        let mut sess = RuntimeSession::new(open_files);
+        sess.container_started = true;
+        sess.container_status = 1;
+        sess.container_pid = -1;
+        // No children left: previously this returned KeepRunning forever.
+        assert!(matches!(
+            sess.poll_children_once()?,
+            PollChildrenResult::StopEventLoop
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn idle_callback_stops_when_container_already_exited() -> ConmonResult<()> {
+        let open_files = OpenFilesSnapshot::default();
+        let mut sess = RuntimeSession::new(open_files);
+        sess.container_started = true;
+        sess.container_status = 0;
+        sess.container_pid = -1;
+        assert!(!sess.idle_callback(false)?);
         Ok(())
     }
 

--- a/src/runtime/stdio.rs
+++ b/src/runtime/stdio.rs
@@ -330,7 +330,10 @@ where
                     // If the POLLIN comes from the signal fd, run the idle_callback to handle
                     // the received signal.
                     if pfd.as_fd().as_raw_fd() == signal_fd {
-                        idle_callback(true)?;
+                        if !idle_callback(true)? {
+                            info!("idle_callback stopped the event loop after signal.");
+                            return Ok(());
+                        }
                         i += 1;
                         continue;
                     }
@@ -407,6 +410,12 @@ where
                 // Do NOT increment the `i`, since it now points to swapped fd.
             }
         }
+    }
+
+    // All remote sockets closed; probe for a container that exited while I/O drained.
+    let keep_running = idle_callback(false)?;
+    if !keep_running {
+        info!("idle_callback stopped the event loop after sockets closed.");
     }
     Ok(())
 }


### PR DESCRIPTION
Cache fast-exiting exec children, stop the event loop once the container has exited, report timeout as -1, and reap pending children before writing the sync pipe so podman receives the correct exit code without hanging.