### PR TITLE
fix: clear stale attach FDs before OwnedFd drop

### DIFF
--- a/src/runtime/stdio.rs
+++ b/src/runtime/stdio.rs
@@ -168,6 +168,22 @@ pub fn receive_console_fd(console_socket: UnixSocket) -> ConmonResult<RemoteSock
     ))
 }
 
+/// Remove a console/terminal peer FD from forward lists before its `OwnedFd` is dropped.
+fn remove_forward_fd(console_fds: &mut Vec<RawFd>, terminal_fds: &mut Vec<RawFd>, socket: &Socket) {
+    let Socket::Remote(remote) = socket else {
+        return;
+    };
+
+    let fds = match remote.socket_type {
+        SocketType::Console => console_fds,
+        SocketType::Terminal => terminal_fds,
+        _ => return,
+    };
+
+    let fd = remote.fd.as_raw_fd();
+    fds.retain(|&candidate| candidate != fd);
+}
+
 /// Handles incomming data on fds and forwards them to right destination.
 /// This function blocks until the container is running.
 /// # Arguments
@@ -379,18 +395,18 @@ where
                 // Remove it from fds we call poll for.
                 fds[i].set_events(PollFlags::empty());
 
+                // Stop forwarding container output/input to this closed peer.
+                remove_forward_fd(&mut console_fds, &mut terminal_fds, &sockets[i]);
+
                 if let Socket::Remote(r) = &sockets[i] {
                     if r.socket_type == SocketType::Console && stdin_attached {
                         // We closed the Console socket attached to container's stdin.
                         // This normally means we also close the container's stdin, unless
                         // the called instructed us no to do it using the `--leave-stdin-open`.
-                        // console_fds.retain(|&x| x != r.fd.as_raw_fd());
                         if !leave_stdin_open {
                             // This closes the socket, since it moves out of scope.
                             workerfd_stdin.take();
                         }
-                    } else if r.socket_type == SocketType::Terminal {
-                        terminal_fds.retain(|&x| x != r.fd.as_raw_fd());
                     }
                 }
             }
@@ -399,7 +415,10 @@ where
                 // Go to next socket in case we want to keep this one.
                 i += 1;
             } else {
-                // Remove the fd completely.
+                // Remove the fd completely. Dropping the socket closes the OwnedFd,
+                // so clear it from forward lists first to avoid later writev/write
+                // to a recycled FD number.
+                remove_forward_fd(&mut console_fds, &mut terminal_fds, &sockets[i]);
                 let socket = sockets.swap_remove(i);
                 info!("Removing socket {:?}", socket);
                 fds.swap_remove(i);
@@ -463,6 +482,38 @@ mod tests {
         let mut buf = [0u8; 16];
         let recv = recv_data_and_fds(receiver.as_raw_fd(), &mut buf);
         assert_eq!(recv.err(), Some(Errno::ENOBUFS));
+        Ok(())
+    }
+
+    #[test]
+    fn socket_removal_clears_forward_fd_before_owned_fd_drop() -> ConmonResult<()> {
+        // Mirrors the event-loop removal path: remove_forward_fd, then swap_remove/drop.
+        let (attach_r, _attach_w) = pipe2(OFlag::O_CLOEXEC)?;
+        let stale_fd = attach_r.as_raw_fd();
+        let mut sockets = vec![Socket::Remote(RemoteSocket::new(
+            SocketType::Console,
+            attach_r,
+        ))];
+        let mut console_fds = vec![stale_fd];
+        let mut terminal_fds = Vec::new();
+
+        remove_forward_fd(&mut console_fds, &mut terminal_fds, &sockets[0]);
+        let removed = sockets.swap_remove(0);
+        drop(removed);
+
+        assert!(
+            !console_fds.contains(&stale_fd),
+            "stale attach FD must be cleared before OwnedFd drop"
+        );
+
+        let (new_r, _new_w) = pipe2(OFlag::O_CLOEXEC)?;
+        let reused = new_r.as_raw_fd();
+        if reused == stale_fd {
+            assert!(
+                !console_fds.contains(&reused),
+                "recycled FD number must not remain in console_fds"
+            );
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
Attach/terminal peers were left in console_fds/terminal_fds after EOF or HUP, so later writev/write could target a recycled FD number. Remove the raw FD from the forwarding lists before dropping the owning Socket.